### PR TITLE
TESTINGABCD registration files for Internal API Developer Portal

### DIFF
--- a/TESTINGABCD.yaml
+++ b/TESTINGABCD.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: TESTINGABCD
+  description: Test
+  labels:
+    access: private
+  tags: []
+spec:
+  type: platform domain
+  lifecycle: development
+  owner: testrepo
+  definition:
+    $text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/testingabcd/latest.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: TestRepoOne
+spec:
+  targets:
+    - ./TESTINGABCD.yaml


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.