### PR TITLE
TESTINGABCD registration files for Internal API Developer Portal

### DIFF
--- a/TESTINGABCD.yaml
+++ b/TESTINGABCD.yaml
@@ -2,13 +2,13 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: TESTINGABCD
-  description: Test
+  description: test desc
   labels:
     access: private
   tags: []
 spec:
   type: platform domain
   lifecycle: development
-  owner: testrepo
+  owner: testing
   definition:
     $text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/testingabcd/latest.json


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.