### PR TITLE
TESTINGABCDE registration files for Internal API Developer Portal

### DIFF
--- a/TESTINGABCDE.yaml
+++ b/TESTINGABCDE.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: TESTINGABCDE
+  description: test desc
+  labels:
+    access: internal
+  tags: []
+spec:
+  type: business domain
+  lifecycle: production
+  owner: testing
+  definition:
+    $text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/testingabcde/latest.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   targets:
     - ./TESTINGABCD.yaml
+    - ./TESTINGABCDE.yaml


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.