### PR TITLE
TestAppCode registration files for Internal API Developer Portal

### DIFF
--- a/TestAppCode.yaml
+++ b/TestAppCode.yaml
@@ -1,0 +1,16 @@
+ApiVersion: backstage.io/v1alpha1
+Kind: API
+Metadata:
+  Name: TestApi
+  Description: TestApi Desc.
+  Labels:
+    Access: private
+  Tags:
+  - marketplace
+  Links: []
+Spec:
+  Type: single-use
+  Lifecycle: development
+  Owner: DeveloperPortalTeam
+  Definition:
+    Text: https://github.com/Paylocity/Paylocity.DeveloperPortal.Specifications/blob/main/local/default/TestAppCode/latest.json

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: TestRepoOne
+spec:
+  targets:
+  - ./TestAppCode.yaml


### PR DESCRIPTION
The `catalog-info.yaml` file will live in the root of the repository and point to the registration files in this repository. Both files are necessary for consistency with monorepos and service discovery. 
 NOTE: Once merged, the API registration will show up in the Internal API Developer Portal within two hours.